### PR TITLE
Add a .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text=auto
+*.ts    eol=lf
+*.tsx   eol=lf
+*.sol   eol=lf
+*.json  eol=lf
+*.svg   eol=lf


### PR DESCRIPTION
### Description of changes proposed in this pull request:
- Add a .gitattributes
- configure with * text=auto

```text=auto``` does the following as per the documentation:

- When text is set to "auto", the path is marked for automatic end-of-line normalization.

-  If Git decides that the content is text, its line endings are normalized to LF on checkin.


https://stackoverflow.com/questions/21472971/what-is-the-purpose-of-text-auto-in-gitattributes-file
https://dev.to/deadlybyte/please-add-gitattributes-to-your-git-repository-1jld


### Checks:
* [X] Have you followed the guidelines in our Contributing document?

### Changes to Existing Features:
* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
There are some file EOL inconsistencies in the repo from either tools or IDEs misconfigurations. 
Example:
contracts/*.sol
Git attributes can be utilized to help alleviate these issues.