### PR TITLE
Added contract allowance check on the synth when initiating a settle.

### DIFF
--- a/src/hooks/useSynthActions.ts
+++ b/src/hooks/useSynthActions.ts
@@ -190,6 +190,10 @@ export const useSynthActions = () => {
 
   const onSettle = useCallback(async () => {
     try {
+      if (synthApproval) {
+        // allowance hasn't been set, initiate that tx first.
+        await onApproveSynth();
+      }
       const txReceipt = await emp.settle(synth);
       console.log(txReceipt.transactionHash);
     } catch (err) {


### PR DESCRIPTION
### Description of changes proposed in this pull request:

- There is currently an issue if a user does not in the lifecycle of their position redeem or burn any synth tokens. These are the only places in which a check is made for the allowance on the EMP. The proposed solution is to check for an allowance and if not available then to initiate an approval tx. 

### Checks:

- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?